### PR TITLE
Fix KubeJS recipes

### DIFF
--- a/kubejs/server_scripts/balance.js
+++ b/kubejs/server_scripts/balance.js
@@ -812,24 +812,4 @@ cableTypes.forEach((type) => {
       "oresabovediamonds:black_opal_block"
     )
   })
-
-event.custom(
-  {
-    "type":"create:compacting",
-    "ingredients":
-    [
-      {
-        "item":"nethers_exoticism:jaboticaba"
-      }
-    ],
-    "results":
-    [
-      {
-        "fluid":"nethers_exoticism:jaboticaba_juice",
-        "amount":250,
-        "nbt":"null"
-      }
-    ]
-  }
-)
 });

--- a/kubejs/server_scripts/mystical/mysticalbalance.js
+++ b/kubejs/server_scripts/mystical/mysticalbalance.js
@@ -34,7 +34,7 @@ event.custom(
     },
     "result":
     {
-      "tag": "forge:ingots/steel",
+      "item": "assemblylinemachines:steel_ingot",
       "count":3
     }
   }
@@ -57,7 +57,7 @@ event.custom(
     },
     "result":
     {
-      "tag": "forge:ingots/lead",
+      "item": "thermal:lead_ingot",
       "count":4
     }
   }
@@ -80,7 +80,7 @@ event.custom(
     },
     "result":
     {
-      "tag": "forge:ingots/zinc",
+      "item": "create:zinc_ingot",
       "count":4
     }
   }
@@ -103,7 +103,7 @@ event.custom(
     },
     "result":
     {
-      "tag": "forge:dusts/sulfur",
+      "item": "thermal:sulfur_dust",
       "count":4
     }
   }
@@ -126,7 +126,7 @@ event.custom(
     },
     "result":
     {
-      "tag": "forge:ingots/tin",
+      "item": "thermal:tin_ingot",
       "count":4
     }
   }
@@ -149,7 +149,7 @@ event.custom(
     },
     "result":
     {
-      "tag":"forge:ingots/bronze",
+      "item": "thermal:bronze_ingot",
       "count":4
     }
   }
@@ -172,7 +172,7 @@ event.custom(
     },
     "result":
     {
-      "tag": "forge:ingots/aluminum",
+      "item": "futurepack:ingot_aluminium",
       "count":8
     }
   }


### PR DESCRIPTION
Steel, lead, zinc, sulfur, tin, bronze, and aluminum essences are now able to be crafted into their respective ingot/dust.
A redundant jabuticaba recipe has also been removed.